### PR TITLE
Add Cloud Pak for Data 4.0.4 support

### DIFF
--- a/cpo/commands/cpd4/service/install.py
+++ b/cpo/commands/cpd4/service/install.py
@@ -39,8 +39,9 @@ from cpo.utils.logging import loglevel_command
 @click.option("--accept-license", help="Accept IBM Cloud Pak for Data license", is_flag=True)
 @click.option(
     "--catalog-source",
-    help="Catalog source for the service operator. If not specified, use default catalog for the operator \
-(usually 'ibm-operator-catalog')",
+    default="ibm-operator-catalog",
+    help="Catalog source for the service operator",
+    show_default=True,
 )
 @click.option(
     "--installation-option",
@@ -81,7 +82,7 @@ def install(
     token: str,
     insecure_skip_tls_verify: Optional[bool],
     accept_license: bool,
-    catalog_source: Optional[str],
+    catalog_source: str,
     installation_option: List[Tuple[str, Union[bool, int, str]]],
     license: Optional[str],
     project: str,

--- a/cpo/deps/config/cpd-custom-resources.json
+++ b/cpo/deps/config/cpd-custom-resources.json
@@ -77,6 +77,21 @@
 		"storage_option_required": false,
 		"version": "v1beta1"
 	},
+	"edb": {
+		"group": "edb.cpd.ibm.com",
+		"description": "EDB Postgres",
+		"kind": "CPDEdbService",
+		"licenses": [
+			"Enterprise",
+			"Standard"
+		],
+		"name": "cpd-edb-service",
+		"operator_name": "ibm-cpd-edb",
+		"spec": {},
+		"status_key_name": "edbStatus",
+		"storage_option_required": true,
+		"version": "v1"
+	},
 	"wml": {
 		"group": "wml.cpd.ibm.com",
 		"description": "Watson Machine Learning",
@@ -89,7 +104,7 @@
 		"operator_name": "ibm-cpd-wml-operator",
 		"spec": {},
 		"status_key_name": "wmlStatus",
-		"storage_option_required": false,
+		"storage_option_required": true,
 		"version": "v1beta1"
 	},
 	"ws": {

--- a/cpo/deps/config/cpd-operand-requests.json
+++ b/cpo/deps/config/cpd-operand-requests.json
@@ -1,0 +1,16 @@
+{
+	"common-service-edb": {
+		"spec": {
+			"requests": [
+				{
+					"operands": [
+						{
+							"name": "cloud-native-postgresql"
+						}
+					],
+					"registry": "common-service"
+				}
+			]
+		}
+	}
+}

--- a/cpo/deps/config/cpd-subscriptions.json
+++ b/cpo/deps/config/cpd-subscriptions.json
@@ -7,6 +7,7 @@
 			"app.kubernetes.io/name": "ibm-cpd-ae-operator-subscription"
 		},
 		"name": "ibm-cpd-ae-operator-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -14,21 +15,11 @@
 			"name": "analyticsengine-operator"
 		}
 	},
-	"cloud-native-postgresql": {
-		"dependencies": [],
-		"labels": {},
-		"name": "cloud-native-postgresql-catalog-subscription",
-		"required_namespace": "openshift-operators",
-		"service": true,
-		"spec": {
-			"channel": "stable",
-			"name": "cloud-native-postgresql"
-		}
-	},
 	"cpd-platform-operator": {
 		"dependencies": [],
 		"labels": {},
 		"name": "cpd-operator",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": false,
 		"spec": {
@@ -40,6 +31,7 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-db2u-operator",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -53,6 +45,7 @@
 		],
 		"labels": {},
 		"name": "ibm-bigsql-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -68,6 +61,7 @@
 			"app.kubernetes.io/name": "ibm-ca-operator"
 		},
 		"name": "ibm-ca-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -83,6 +77,7 @@
 			"app.kubernetes.io/name": "ibm-cde-operator-subscription"
 		},
 		"name": "ibm-cde-operator-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -94,6 +89,7 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-common-service-operator",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": false,
 		"spec": {
@@ -105,6 +101,7 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-cpd-datastage-operator-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -120,6 +117,7 @@
 			"app.kubernetes.io/name": "ibm-cpd-dods-operator-catalog-subscription"
 		},
 		"name": "ibm-cpd-dods-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -127,12 +125,29 @@
 			"name": "ibm-cpd-dods"
 		}
 	},
+	"ibm-cpd-dp": {
+		"dependencies": [],
+		"labels": {
+			"app.kubernetes.io/instance": "ibm-cpd-dp-operator-catalog-subscription",
+			"app.kubernetes.io/managed-by": "ibm-cpd-dp-operator",
+			"app.kubernetes.io/name": "ibm-cpd-dp-operator-catalog-subscription"
+		},
+		"name": "ibm-cpd-dp-operator-catalog-subscription",
+		"operand_request_dependencies": [],
+		"required_namespace": null,
+		"service": true,
+		"spec": {
+			"channel": "v1.0",
+			"name": "ibm-cpd-dp"
+		}
+	},
 	"ibm-cpd-edb": {
-		"dependencies": [
-			"cloud-native-postgresql"
-		],
+		"dependencies": [],
 		"labels": {},
 		"name": "ibm-cpd-edb-operator-catalog-subscription",
+		"operand_request_dependencies": [
+			"common-service-edb"
+		],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -148,6 +163,7 @@
 			"app.kubernetes.io/name": "ibm-cpd-hadoop-operator-catalog-subscription"
 		},
 		"name": "ibm-cpd-hadoop-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -161,6 +177,7 @@
 		],
 		"labels": {},
 		"name": "ibm-cpd-mongodb-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -172,6 +189,7 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-cpd-openpages-operator",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -183,10 +201,11 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-productmaster-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
-			"channel": "alpha",
+			"channel": "v1.0",
 			"name": "ibm-cpd-productmaster"
 		}
 	},
@@ -198,6 +217,7 @@
 			"app.kubernetes.io/name": "ibm-cpd-rstudio-operator-catalog-subscription"
 		},
 		"name": "ibm-cpd-rstudio-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -213,6 +233,7 @@
 			"app.kubernetes.io/name": "ibm-cpd-spss-operator-catalog-subscription"
 		},
 		"name": "ibm-cpd-spss-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -230,6 +251,7 @@
 			"app.kubernetes.io/name": "ibm-cpd-wkc-operator-catalog-subscription"
 		},
 		"name": "ibm-cpd-wkc-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -241,10 +263,11 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-cpd-wml-accelerator-operator",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
-			"channel": "WML-Accelerator-2.3",
+			"channel": "v1.0",
 			"name": "ibm-cpd-wml-accelerator-operator"
 		}
 	},
@@ -256,6 +279,7 @@
 			"app.kubernetes.io/name": "ibm-cpd-wml-operator-subscription"
 		},
 		"name": "ibm-cpd-wml-operator-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -271,6 +295,7 @@
 			"app.kubernetes.io/name": "ibm-watson-openscale-operator-subscription"
 		},
 		"name": "ibm-watson-openscale-operator-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -286,6 +311,7 @@
 			"app.kubernetes.io/name": "ibm-cpd-ws-runtimes-operator"
 		},
 		"name": "ibm-cpd-ws-runtimes-operator",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -297,6 +323,7 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-cpd-ws-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -312,6 +339,7 @@
 			"app.kubernetes.io/name": "ibm-datagate-operator-subscription"
 		},
 		"name": "ibm-datagate-operator-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -325,6 +353,7 @@
 		],
 		"labels": {},
 		"name": "ibm-db2oltp-cp4d-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -338,6 +367,7 @@
 		],
 		"labels": {},
 		"name": "ibm-db2wh-cp4d-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -349,6 +379,7 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-dmc-operator-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -362,6 +393,7 @@
 		],
 		"labels": {},
 		"name": "ibm-dv-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -375,10 +407,11 @@
 		],
 		"labels": {},
 		"name": "ibm-informix-cp4d-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
-			"channel": "v1",
+			"channel": "v1.0",
 			"name": "ibm-informix-cp4d-operator"
 		}
 	},
@@ -386,10 +419,11 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-informix-operator-catalog-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
-			"channel": "stable",
+			"channel": "v1.0",
 			"name": "ibm-informix-operator"
 		}
 	},
@@ -401,6 +435,7 @@
 			"app.kubernetes.io/name": "ibm-mdm-operator-subscription"
 		},
 		"name": "ibm-mdm-operator-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -412,6 +447,7 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-planning-analytics-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -423,6 +459,7 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-voice-gateway-operator-subscription",
+		"operand_request_dependencies": [],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -434,6 +471,9 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-watson-assistant-operator-subscription",
+		"operand_request_dependencies": [
+			"common-service-edb"
+		],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -449,6 +489,9 @@
 			"app.kubernetes.io/name": "ibm-watson-discovery-operator-subscription"
 		},
 		"name": "ibm-watson-discovery-operator-subscription",
+		"operand_request_dependencies": [
+			"common-service-edb"
+		],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -464,6 +507,9 @@
 			"app.kubernetes.io/name": "ibm-watson-ks-operator-subscription"
 		},
 		"name": "ibm-watson-ks-operator-subscription",
+		"operand_request_dependencies": [
+			"common-service-edb"
+		],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -475,6 +521,9 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-watson-speech-operator-subscription",
+		"operand_request_dependencies": [
+			"common-service-edb"
+		],
 		"required_namespace": null,
 		"service": true,
 		"spec": {
@@ -486,7 +535,8 @@
 		"dependencies": [],
 		"labels": {},
 		"name": "ibm-mongodb-enterprise-catalog-subscription",
-		"required_namespace": "openshift-operators",
+		"operand_request_dependencies": [],
+		"required_namespace": null,
 		"service": true,
 		"spec": {
 			"channel": "stable",

--- a/cpo/lib/cloud_pak_for_data/cpd_4_0_0/catalog_source_manager.py
+++ b/cpo/lib/cloud_pak_for_data/cpd_4_0_0/catalog_source_manager.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 IBM Corporation
+#  Copyright 2021, 2022 IBM Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -22,29 +22,6 @@ class CatalogSourceManager:
     """Manages OpenShift catalog sources"""
 
     def __init__(self):
-        self._catalog_sources: CatalogSourceList = [
-            {
-                "apiVersion": CatalogSourceManager._API_VERSION,
-                "kind": "CatalogSource",
-                "metadata": {
-                    "name": "ibm-db2uoperator-catalog",
-                    "namespace": "openshift-marketplace",
-                },
-                "spec": {
-                    "displayName": "IBM Db2U Catalog",
-                    "image": "docker.io/ibmcom/ibm-db2uoperator-catalog:latest",
-                    "imagePullPolicy": "Always",
-                    "publisher": "IBM",
-                    "sourceType": "grpc",
-                    "updateStrategy": {
-                        "registryPoll": {
-                            "interval": "45m",
-                        },
-                    },
-                },
-            },
-        ]
-
         self._catalog_sources_foundational_services: CatalogSourceList = [
             {
                 "apiVersion": CatalogSourceManager._API_VERSION,
@@ -67,17 +44,6 @@ class CatalogSourceManager:
             },
         ]
 
-    def get_catalog_sources(self) -> CatalogSourceList:
-        """Returns OpenShift catalog sources for IBM Cloud Pak for Data services
-
-        Returns
-        -------
-        CatalogSourceList
-            list of OpenShift catalog sources
-        """
-
-        return self._catalog_sources
-
     def get_catalog_sources_for_foundational_services(self) -> CatalogSourceList:
         """Returns OpenShift catalog sources for IBM Cloud Pak for Data
         foundational services
@@ -89,22 +55,6 @@ class CatalogSourceManager:
         """
 
         return self._catalog_sources_foundational_services
-
-    def get_catalog_source_names(self) -> List[str]:
-        """Returns OpenShift catalog source names for IBM Cloud Pak for Data
-        services
-
-        Returns
-        -------
-        List[str]
-            list of OpenShift catalog sources names
-        """
-
-        return reduce(
-            lambda result, catalog_source: result + [catalog_source["metadata"]["name"]],
-            self._catalog_sources,
-            [],
-        )
 
     def get_catalog_source_names_for_foundational_services(self) -> List[str]:
         """Returns OpenShift catalog source names for IBM Cloud Pak for Data

--- a/cpo/lib/cloud_pak_for_data/cpd_4_0_0/cpd_operand_manager.py
+++ b/cpo/lib/cloud_pak_for_data/cpd_4_0_0/cpd_operand_manager.py
@@ -1,0 +1,118 @@
+#  Copyright 2022 IBM Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+
+from typing import Dict
+
+import jsonschema
+
+import cpo.config
+
+from cpo.lib.cloud_pak_for_data.cpd_4_0_0.types.operand_request_metadata import (
+    OperandRequestMetadata,
+)
+from cpo.lib.error import DataGateCLIException
+
+
+class CloudPakForDataOperandManager:
+    """Manages IBM Cloud Pak for Data operand requests"""
+
+    def __init__(self):
+        self._json_schema = {
+            "additionalProperties": {
+                "additionalProperties": False,
+                "properties": {
+                    "spec": {
+                        "additionalProperties": False,
+                        "properties": {
+                            "requests": {
+                                "items": {
+                                    "additionalProperties": False,
+                                    "properties": {
+                                        "operands": {
+                                            "items": {
+                                                "additionalProperties": False,
+                                                "properties": {
+                                                    "name": {"type": "string"},
+                                                },
+                                                "required": [
+                                                    "name",
+                                                ],
+                                                "type": "object",
+                                            },
+                                            "type": "array",
+                                        },
+                                        "registry": {"type": "string"},
+                                    },
+                                    "required": [
+                                        "operands",
+                                        "registry",
+                                    ],
+                                    "type": "object",
+                                },
+                                "type": "array",
+                            },
+                        },
+                        "required": [
+                            "requests",
+                        ],
+                        "type": "object",
+                    },
+                },
+                "required": [
+                    "spec",
+                ],
+                "type": "object",
+            },
+        }
+
+        self._operands: Dict[str, OperandRequestMetadata] = {}
+
+    def get_operand_request_metadata(self, operand_request_name: str) -> OperandRequestMetadata:
+        """Returns operand request metadata for the given operand request name
+
+        Parameters
+        ----------
+        operand request name
+            name of the operand request for which operand request metadata shall be
+            returned
+
+        Returns
+        -------
+        OperandRequestMetadata
+            operand request metadata object
+        """
+
+        self._initialize_operands_dict_if_required()
+
+        if operand_request_name not in self._operands:
+            raise DataGateCLIException("Unknown IBM Cloud Pak for Data service")
+
+        return self._operands[operand_request_name]
+
+    def _initialize_operands_dict_if_required(self):
+        if len(self._operands) == 0:
+            with open(
+                cpo.config.configuration_manager.get_deps_directory_path() / "config" / "cpd-operand-requests.json"
+            ) as cpd_operand_requests_file:
+                cpd_operand_requests_file_contents = json.load(cpd_operand_requests_file)
+
+                jsonschema.Draft7Validator(self._json_schema).validate(cpd_operand_requests_file_contents)
+
+                for key, value in cpd_operand_requests_file_contents.items():
+                    self._operands[key] = value
+
+
+cloud_pak_for_data_operand_manager = CloudPakForDataOperandManager()

--- a/cpo/lib/cloud_pak_for_data/cpd_4_0_0/cpd_service_manager.py
+++ b/cpo/lib/cloud_pak_for_data/cpd_4_0_0/cpd_service_manager.py
@@ -151,11 +151,11 @@ class CloudPakForDataServiceManager:
                         dependencies=value["dependencies"],
                         labels=value["labels"],
                         name=value["name"],
+                        operand_request_dependencies=value["operand_request_dependencies"],
                         required_namespace=value["required_namespace"],
                         service=value["service"],
                         spec=SubscriptionMetadataSpec(
                             channel=value["spec"]["channel"],
                             name=value["spec"]["name"],
-                            source=value["spec"].get("source"),
                         ),
                     )

--- a/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/custom_resource_event_data.py
+++ b/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/custom_resource_event_data.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 IBM Corporation
+#  Copyright 2021, 2022 IBM Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@ from dataclasses import dataclass
 
 from halo.halo import Halo
 
+from cpo.lib.cloud_pak_for_data.cpd_4_0_0.types.status_key_data import StatusKeyData
+
 
 @dataclass
 class CustomResourceEventData:
-    name: str
-    spinner: Halo
-    status_key: str
+    custom_resource_name: str
     initial_event = True
+    spinner: Halo
+    status_key_data: StatusKeyData

--- a/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/operand_request_metadata.py
+++ b/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/operand_request_metadata.py
@@ -1,4 +1,4 @@
-#  Copyright 2021, 2022 IBM Corporation
+#  Copyright 2022 IBM Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,27 +12,21 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import TypedDict, Union
+from typing import List, TypedDict
 
 
-class LastStatus(TypedDict):
-    cluster_id: str
-    status: str
+class Operand(TypedDict):
+    name: str
 
 
-class RequestData(TypedDict):
-    complete: str
-    completion_percent: int
-    failed: str
-    in_progress: str
-    job_count: str
-    last_status_time: str
-    last_status: Union[LastStatus, str]
-    pending: str
-    request_id: str
-    task_count: str
+class Request(TypedDict):
+    operands: List[Operand]
+    registry: str
 
 
-class OCPRequestGetResponse(TypedDict):
-    request: RequestData
-    status: str
+class OperandRequestSpec(TypedDict):
+    requests: List[Request]
+
+
+class OperandRequestMetadata(TypedDict):
+    spec: OperandRequestSpec

--- a/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/status_key_data.py
+++ b/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/status_key_data.py
@@ -1,4 +1,4 @@
-#  Copyright 2021, 2022 IBM Corporation
+#  Copyright 2022 IBM Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,27 +12,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import TypedDict, Union
+
+from dataclasses import dataclass
+from typing import Optional
+
+from cpo.lib.cloud_pak_for_data.cpd_4_0_0.types.status_key_value import StatusKeyValue
 
 
-class LastStatus(TypedDict):
-    cluster_id: str
-    status: str
-
-
-class RequestData(TypedDict):
-    complete: str
-    completion_percent: int
-    failed: str
-    in_progress: str
-    job_count: str
-    last_status_time: str
-    last_status: Union[LastStatus, str]
-    pending: str
-    request_id: str
-    task_count: str
-
-
-class OCPRequestGetResponse(TypedDict):
-    request: RequestData
-    status: str
+@dataclass
+class StatusKeyData:
+    failure_value: Optional[StatusKeyValue]
+    status_key_name: str
+    success_value: StatusKeyValue

--- a/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/status_key_value.py
+++ b/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/status_key_value.py
@@ -1,4 +1,4 @@
-#  Copyright 2021, 2022 IBM Corporation
+#  Copyright 2022 IBM Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,27 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import TypedDict, Union
+from enum import Enum
 
 
-class LastStatus(TypedDict):
-    cluster_id: str
-    status: str
-
-
-class RequestData(TypedDict):
-    complete: str
-    completion_percent: int
-    failed: str
-    in_progress: str
-    job_count: str
-    last_status_time: str
-    last_status: Union[LastStatus, str]
-    pending: str
-    request_id: str
-    task_count: str
-
-
-class OCPRequestGetResponse(TypedDict):
-    request: RequestData
-    status: str
+class StatusKeyValue(Enum):
+    Completed = "Completed"
+    Failed = "Failed"
+    Running = "Running"

--- a/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/subscription_metadata.py
+++ b/cpo/lib/cloud_pak_for_data/cpd_4_0_0/types/subscription_metadata.py
@@ -24,7 +24,6 @@ class SubscriptionMetadataSpec:
 
     channel: str
     name: str
-    source: Optional[str] = None
 
 
 @dataclass
@@ -34,11 +33,12 @@ class SubscriptionMetadata:
     dependencies: List[str]
     labels: Dict[str, str]
     name: str
+    operand_request_dependencies: List[str]
     required_namespace: Optional[str]
     service: bool
     spec: SubscriptionMetadataSpec
 
-    def get_subscription(self, project: str, catalog_source: Optional[str] = None) -> Subscription:
+    def get_subscription(self, project: str, catalog_source: str) -> Subscription:
         """Returns a specification object for passing to the OpenShift REST API
         when creating a subscription
 
@@ -55,12 +55,6 @@ class SubscriptionMetadata:
         Subscription
             subscription object
         """
-        if catalog_source is not None:
-            source = catalog_source
-        elif self.spec.source is not None:
-            source = self.spec.source
-        else:
-            source = "ibm-operator-catalog"
 
         subscription: Subscription = {
             "apiVersion": "operators.coreos.com/v1alpha1",
@@ -73,7 +67,7 @@ class SubscriptionMetadata:
                 "channel": self.spec.channel,
                 "installPlanApproval": "Automatic",
                 "name": self.spec.name,
-                "source": source,
+                "source": catalog_source,
                 "sourceNamespace": "openshift-marketplace",
             },
         }

--- a/cpo/lib/openshift/types/custom_resource_event_result.py
+++ b/cpo/lib/openshift/types/custom_resource_event_result.py
@@ -1,4 +1,4 @@
-#  Copyright 2021, 2022 IBM Corporation
+#  Copyright 2022 IBM Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,27 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import TypedDict, Union
+from dataclasses import dataclass
+from typing import Optional
 
 
-class LastStatus(TypedDict):
-    cluster_id: str
-    status: str
-
-
-class RequestData(TypedDict):
-    complete: str
-    completion_percent: int
-    failed: str
-    in_progress: str
-    job_count: str
-    last_status_time: str
-    last_status: Union[LastStatus, str]
-    pending: str
-    request_id: str
-    task_count: str
-
-
-class OCPRequestGetResponse(TypedDict):
-    request: RequestData
-    status: str
+@dataclass
+class CustomResourceEventResult:
+    succeeded: bool
+    message: Optional[str] = None

--- a/cpo/utils/importlib.py
+++ b/cpo/utils/importlib.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 IBM Corporation
+#  Copyright 2021, 2022 IBM Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/docs/installing_ibm_cloud_pak_for_data_on_a_fyre-based_openshift_cluster.md
+++ b/docs/installing_ibm_cloud_pak_for_data_on_a_fyre-based_openshift_cluster.md
@@ -9,7 +9,7 @@
 - Create a new OCP+ cluster for IBM Db2 Data Gate on IBM Cloud Pak for Data:
 
   ```shell
-  cpo fyre cluster create --alias $ALIAS --cluster-name $FYRE_CLUSTER_NAME --ssh-key "$(cat ~/.ssh/id_rsa.pub)" --worker-node-num-cpus 16 --worker-node-ram-size 64
+  cpo fyre cluster create --alias $ALIAS --cluster-name $FYRE_CLUSTER_NAME --ocp-version 4.8 --ssh-key "$(cat ~/.ssh/id_rsa.pub)" --worker-node-num-cpus 16 --worker-node-ram-size 64
   ```
 
 - Set the current registered OpenShift cluster:


### PR DESCRIPTION
This pull request contains the following changes:

- Add support for Cloud Pak for Data 4.0.4
- Add support for creating operand requests, which are a prerequisite for installing certain Cloud Pak for Data services
- Support "EDB Postgres" service installation
- Add default value to `--catalog-source` option of `cpo cpd4 service install command`
- Remove unused `ibm-db2uoperator-catalog` catalog source
