### PR TITLE
https://github.com/IBM/cloud-pak-operations-cli/issues/111

### DIFF
--- a/cpo/lib/fyre/response_managers/ocp_get_response_manager.py
+++ b/cpo/lib/fyre/response_managers/ocp_get_response_manager.py
@@ -76,7 +76,6 @@ class OCPGetResponseManager(AbstractJSONResponseManager):
                         "description",
                         "expiration",
                         "fips_enabled",
-                        "initial_ocp_version",
                         "kubeadmin_password",
                         "location_name",
                         "locked_for_delete",

--- a/cpo/lib/fyre/response_managers/ocp_get_response_manager_for_single_cluster.py
+++ b/cpo/lib/fyre/response_managers/ocp_get_response_manager_for_single_cluster.py
@@ -74,7 +74,6 @@ class OCPGetResponseManagerForSingleCluster(AbstractJSONResponseManager):
                         "description",
                         "expiration",
                         "fips_enabled",
-                        "initial_ocp_version",
                         "kubeadmin_password",
                         "locked_for_delete",
                         "ocp_username",


### PR DESCRIPTION
initial_ocp_version is not a required field because Fyre does not return it in case of a new cluster apparently.