### PR TITLE
Add --disable-strict-response-schema-check option to Fyre commands

### DIFF
--- a/cpo/commands/fyre/cluster/accept_transfer.py
+++ b/cpo/commands/fyre/cluster/accept_transfer.py
@@ -37,8 +37,16 @@ from cpo.utils.logging import loglevel_command
     "--cluster-name", help="Name of the OCP+ cluster whose incoming transfer shall be accepted", required=True
 )
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def accept_transfer(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, site: Optional[str]):
+def accept_transfer(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    site: Optional[str],
+):
     """Accept an incoming OCP+ cluster transfer"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).accept_transfer(cluster_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).accept_transfer(
+        cluster_name, site
+    )

--- a/cpo/commands/fyre/cluster/add_worker_node.py
+++ b/cpo/commands/fyre/cluster/add_worker_node.py
@@ -57,6 +57,7 @@ def validate_worker_node_additional_disk_size(ctx, param, value: Optional[List[i
 def add_worker_node(
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     cluster_name: str,
     disable_scheduling: bool,
     force: bool,
@@ -72,7 +73,7 @@ def add_worker_node(
         click.confirm(f"Do you really want to add an additional worker node to cluster '{cluster_name}'?", abort=True)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).add_node(
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).add_node(
         cluster_name,
         disable_scheduling,
         site,

--- a/cpo/commands/fyre/cluster/boot.py
+++ b/cpo/commands/fyre/cluster/boot.py
@@ -36,11 +36,18 @@ from cpo.utils.logging import loglevel_command
 @click.option("--cluster-name", help="Name of the OCP+ cluster to be booted", required=True)
 @click.option("--force", "-f", help="Skip confirmation", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def boot(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, force: bool, site: Optional[str]):
+def boot(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    force: bool,
+    site: Optional[str],
+):
     """Boot an OCP+ cluster"""
 
     if not force:
         click.confirm(f"Do you really want to boot cluster '{cluster_name}'?", abort=True)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).boot(cluster_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).boot(cluster_name, site)

--- a/cpo/commands/fyre/cluster/boot_node.py
+++ b/cpo/commands/fyre/cluster/boot_node.py
@@ -41,6 +41,7 @@ from cpo.utils.logging import loglevel_command
 def boot_node(
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     cluster_name: str,
     force: bool,
     node_name: str,
@@ -52,4 +53,6 @@ def boot_node(
         click.confirm(f"Do you really want to boot node '{node_name}' of cluster '{cluster_name}'?", abort=True)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).boot_node(cluster_name, node_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).boot_node(
+        cluster_name, node_name, site
+    )

--- a/cpo/commands/fyre/cluster/create.py
+++ b/cpo/commands/fyre/cluster/create.py
@@ -37,7 +37,7 @@ from cpo.utils.logging import loglevel_command
 
 def validate_haproxy_timeout_setting(ctx, param, value):
     if value is not None:
-        search_result = regex.match("\\d+[d|h|m|ms|s|us]", value)
+        search_result = regex.match("\\d+(d|h|m|ms|s|us)", value)
 
         if search_result is None:
             raise click.BadParameter("Invalid string format")
@@ -115,6 +115,7 @@ def create(
     ctx: click.Context,  # NOSONAR
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     alias: Optional[str],
     cluster_name: Optional[str],
     description: Optional[str],
@@ -165,7 +166,9 @@ def create(
 
     cpo.utils.network.disable_insecure_request_warning()
 
-    assigned_cluster_name = OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).create_cluster(
+    assigned_cluster_name = OCPPlusAPIManager(
+        fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check
+    ).create_cluster(
         OCPPlusClusterSpecification(
             alias,
             cluster_name,

--- a/cpo/commands/fyre/cluster/create_default.py
+++ b/cpo/commands/fyre/cluster/create_default.py
@@ -35,14 +35,19 @@ from cpo.utils.logging import loglevel_command
 @click.option("--platform", help="Platform", required=True, type=click.Choice(["p", "x", "z"]))
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
 def create_default(
-    fyre_api_user_name: str, fyre_api_key: str, alias: Optional[str], platform: str, site: Optional[str]
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    alias: Optional[str],
+    platform: str,
+    site: Optional[str],
 ):
     """Create a new OCP+ cluster with defaults"""
 
     cpo.utils.network.disable_insecure_request_warning()
 
-    assigned_cluster_name = OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).create_cluster_with_defaults(
-        alias, platform, site
-    )
+    assigned_cluster_name = OCPPlusAPIManager(
+        fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check
+    ).create_cluster_with_defaults(alias, platform, site)
 
     click.echo(f"Created cluster '{assigned_cluster_name}'")

--- a/cpo/commands/fyre/cluster/details.py
+++ b/cpo/commands/fyre/cluster/details.py
@@ -36,8 +36,17 @@ from cpo.utils.logging import loglevel_command
 @click.option("--cluster-name", help="Name of the OCP+ cluster whose details shall be listed", required=True)
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def details(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, json: bool, site: Optional[str]):
+def details(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    json: bool,
+    site: Optional[str],
+):
     """List details of an OCP+ cluster"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_cluster_details(cluster_name, site).format(json)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_cluster_details(
+        cluster_name, site
+    ).format(json)

--- a/cpo/commands/fyre/cluster/disable_delete.py
+++ b/cpo/commands/fyre/cluster/disable_delete.py
@@ -34,8 +34,16 @@ from cpo.utils.logging import loglevel_command
 @fyre_command_options
 @click.option("--cluster-name", help="Name of the OCP+ cluster whose erasability shall be disabled", required=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def disable_delete(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, site: Optional[str]):
+def disable_delete(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    site: Optional[str],
+):
     """Disable erasability of an OCP+ cluster"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).disable_delete(cluster_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).disable_delete(
+        cluster_name, site
+    )

--- a/cpo/commands/fyre/cluster/edit_inf_node.py
+++ b/cpo/commands/fyre/cluster/edit_inf_node.py
@@ -40,6 +40,7 @@ from cpo.utils.logging import loglevel_command
 def edit_inf_node(
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     additional_disk_size: List[int],
     cluster_name: str,
     force: bool,
@@ -54,4 +55,6 @@ def edit_inf_node(
             )
 
         cpo.utils.network.disable_insecure_request_warning()
-        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).edit_inf_node(cluster_name, additional_disk_size, site)
+        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).edit_inf_node(
+            cluster_name, additional_disk_size, site
+        )

--- a/cpo/commands/fyre/cluster/edit_master_node.py
+++ b/cpo/commands/fyre/cluster/edit_master_node.py
@@ -42,6 +42,7 @@ from cpo.utils.logging import loglevel_command
 def edit_master_node(
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     cluster_name: str,
     force: bool,
     node_name: str,
@@ -56,6 +57,6 @@ def edit_master_node(
             click.confirm(f"Do you really want to edit node '{node_name}' of cluster '{cluster_name}'?", abort=True)
 
         cpo.utils.network.disable_insecure_request_warning()
-        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).edit_master_node(
+        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).edit_master_node(
             cluster_name, node_name, node_num_cpus, node_ram_size, site
         )

--- a/cpo/commands/fyre/cluster/edit_worker_node.py
+++ b/cpo/commands/fyre/cluster/edit_worker_node.py
@@ -52,6 +52,7 @@ def validate_node_name(ctx, param, value) -> Optional[str]:
 def edit_worker_node(
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     additional_disk_size: List[int],
     cluster_name: str,
     force: bool,
@@ -67,6 +68,6 @@ def edit_worker_node(
             click.confirm(f"Do you really want to edit node '{node_name}' of cluster '{cluster_name}'?", abort=True)
 
         cpo.utils.network.disable_insecure_request_warning()
-        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).edit_worker_node(
+        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).edit_worker_node(
             cluster_name, node_name, additional_disk_size, node_num_cpus, node_ram_size, site
         )

--- a/cpo/commands/fyre/cluster/enable_delete.py
+++ b/cpo/commands/fyre/cluster/enable_delete.py
@@ -34,8 +34,16 @@ from cpo.utils.logging import loglevel_command
 @fyre_command_options
 @click.option("--cluster-name", help="Name of the OCP+ cluster whose erasability shall be enabled", required=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def enable_delete(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, site: Optional[str]):
+def enable_delete(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    site: Optional[str],
+):
     """Enable erasability of an OCP+ cluster"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).enable_delete(cluster_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).enable_delete(
+        cluster_name, site
+    )

--- a/cpo/commands/fyre/cluster/install_nfs_storage_class.py
+++ b/cpo/commands/fyre/cluster/install_nfs_storage_class.py
@@ -48,6 +48,7 @@ def install_nfs_storage_class(
     ctx: click.Context,
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     cluster_name: str,
     project: str,
     site: Optional[str],
@@ -57,7 +58,7 @@ def install_nfs_storage_class(
     cpo.utils.network.disable_insecure_request_warning()
 
     nfs_server = (
-        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key)
+        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check)
         .get_cluster_details(cluster_name, site)
         .get_private_ip_address_of_infrastructure_node()
     )

--- a/cpo/commands/fyre/cluster/ls.py
+++ b/cpo/commands/fyre/cluster/ls.py
@@ -33,8 +33,16 @@ from cpo.utils.logging import loglevel_command
 @fyre_command_options
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def ls(fyre_api_user_name: str, fyre_api_key: str, json: bool, site: Optional[str]):
+def ls(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    json: bool,
+    site: Optional[str],
+):
     """List OCP+ clusters"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_clusters(site).format(json)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_clusters(site).format(
+        json
+    )

--- a/cpo/commands/fyre/cluster/reboot.py
+++ b/cpo/commands/fyre/cluster/reboot.py
@@ -36,11 +36,18 @@ from cpo.utils.logging import loglevel_command
 @click.option("--cluster-name", help="Name of the OCP+ cluster to be rebooted", required=True)
 @click.option("--force", "-f", help="Skip confirmation", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def reboot(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, force: bool, site: Optional[str]):
+def reboot(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    force: bool,
+    site: Optional[str],
+):
     """Reboot an OCP+ cluster"""
 
     if not force:
         click.confirm(f"Do you really want to reboot cluster '{cluster_name}'?", abort=True)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).reboot(cluster_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).reboot(cluster_name, site)

--- a/cpo/commands/fyre/cluster/reboot_node.py
+++ b/cpo/commands/fyre/cluster/reboot_node.py
@@ -41,6 +41,7 @@ from cpo.utils.logging import loglevel_command
 def reboot_node(
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     cluster_name: str,
     force: bool,
     node_name: str,
@@ -52,4 +53,6 @@ def reboot_node(
         click.confirm(f"Do you really want to reboot node '{node_name}' of cluster '{cluster_name}'?", abort=True)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).reboot_node(cluster_name, node_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).reboot_node(
+        cluster_name, node_name, site
+    )

--- a/cpo/commands/fyre/cluster/redeploy_node.py
+++ b/cpo/commands/fyre/cluster/redeploy_node.py
@@ -49,6 +49,7 @@ def validate_node_name(ctx, param, value) -> Optional[str]:
 def redeploy_node(
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     cluster_name: str,
     force: bool,
     node_name: str,
@@ -60,4 +61,6 @@ def redeploy_node(
         click.confirm(f"Do you really want to redeploy node '{node_name}' of cluster '{cluster_name}'?", abort=True)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).redeploy_node(cluster_name, node_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).redeploy_node(
+        cluster_name, node_name, site
+    )

--- a/cpo/commands/fyre/cluster/rm.py
+++ b/cpo/commands/fyre/cluster/rm.py
@@ -35,14 +35,21 @@ from cpo.utils.logging import loglevel_command
 @click.option("--cluster-name", help="Name of the OCP+ cluster to be deleted", required=True)
 @click.option("--force", "-f", help="Skip confirmation", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def rm(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, force: bool, site: Optional[str]):
+def rm(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    force: bool,
+    site: Optional[str],
+):
     """Delete an OCP+ cluster"""
 
     if not force:
         click.confirm(f"Do you really want to delete cluster '{cluster_name}'?", abort=True)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).rm(cluster_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).rm(cluster_name, site)
 
     server = f"https://api.{cluster_name}.cp.fyre.ibm.com:6443"
     cluster = cpo.config.cluster_credentials_manager.cluster_credentials_manager.get_cluster(server)

--- a/cpo/commands/fyre/cluster/shutdown.py
+++ b/cpo/commands/fyre/cluster/shutdown.py
@@ -36,11 +36,20 @@ from cpo.utils.logging import loglevel_command
 @click.option("--cluster-name", help="Name of the OCP+ cluster to be shut down", required=True)
 @click.option("--force", "-f", help="Skip confirmation", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def shutdown(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, force: bool, site: Optional[str]):
+def shutdown(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    force: bool,
+    site: Optional[str],
+):
     """Shut down an OCP+ cluster"""
 
     if not force:
         click.confirm(f"Do you really want to shut down cluster '{cluster_name}'?", abort=True)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).shutdown(cluster_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).shutdown(
+        cluster_name, site
+    )

--- a/cpo/commands/fyre/cluster/shutdown_node.py
+++ b/cpo/commands/fyre/cluster/shutdown_node.py
@@ -41,6 +41,7 @@ from cpo.utils.logging import loglevel_command
 def shutdown_node(
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     cluster_name: str,
     force: bool,
     node_name: str,
@@ -52,4 +53,6 @@ def shutdown_node(
         click.confirm(f"Do you really want to shut down node '{node_name}' of cluster '{cluster_name}'?", abort=True)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).shutdown_node(cluster_name, node_name, site)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).shutdown_node(
+        cluster_name, node_name, site
+    )

--- a/cpo/commands/fyre/cluster/status.py
+++ b/cpo/commands/fyre/cluster/status.py
@@ -36,8 +36,17 @@ from cpo.utils.logging import loglevel_command
 @click.option("--cluster-name", help="Name of the OCP+ cluster whose status shall be listed", required=True)
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def status(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, json: bool, site: Optional[str]):
+def status(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    json: bool,
+    site: Optional[str],
+):
     """List the status of an OCP+ cluster"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_cluster_status(cluster_name, site).format(json)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_cluster_status(
+        cluster_name, site
+    ).format(json)

--- a/cpo/commands/fyre/cluster/transfer_ownership.py
+++ b/cpo/commands/fyre/cluster/transfer_ownership.py
@@ -43,6 +43,7 @@ def transfer_ownership(
     ctx: click.Context,
     fyre_api_user_name: str,
     fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
     cluster_name: str,
     comment: Optional[str],
     new_owner: Optional[str],
@@ -55,6 +56,6 @@ def transfer_ownership(
         raise click.UsageError("You must set options '--new-owner' and/or '--new-product-group-id'.", ctx)
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).transfer(
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).transfer(
         cluster_name, new_owner, new_product_group_id, comment, site
     )

--- a/cpo/commands/fyre/info/check_cluster_name.py
+++ b/cpo/commands/fyre/info/check_cluster_name.py
@@ -34,8 +34,17 @@ from cpo.utils.logging import loglevel_command
 @click.option("--cluster-name", help="Cluster name to be checked", required=True)
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def check_cluster_name(fyre_api_user_name: str, fyre_api_key: str, cluster_name: str, json: bool, site: Optional[str]):
+def check_cluster_name(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    cluster_name: str,
+    json: bool,
+    site: Optional[str],
+):
     """Check if a cluster name is available"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).check_cluster_name(cluster_name, site).format(json)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).check_cluster_name(
+        cluster_name, site
+    ).format(json)

--- a/cpo/commands/fyre/info/get_default_sizes.py
+++ b/cpo/commands/fyre/info/get_default_sizes.py
@@ -34,8 +34,17 @@ from cpo.utils.logging import loglevel_command
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--platform", help="Platform", required=True, type=click.Choice(["p", "x", "z"]))
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def get_default_sizes(fyre_api_user_name: str, fyre_api_key: str, json: bool, platform: str, site: Optional[str]):
+def get_default_sizes(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    json: bool,
+    platform: str,
+    site: Optional[str],
+):
     """Get default node sizes"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_default_sizes(platform, site).format_default_sizes(json)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_default_sizes(
+        platform, site
+    ).format_default_sizes(json)

--- a/cpo/commands/fyre/info/get_openshift_versions.py
+++ b/cpo/commands/fyre/info/get_openshift_versions.py
@@ -34,10 +34,17 @@ from cpo.utils.logging import loglevel_command
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--platform", help="Platform", required=True, type=click.Choice(["p", "x", "z"]))
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def get_openshift_versions(fyre_api_user_name: str, fyre_api_key: str, json: bool, platform: str, site: Optional[str]):
+def get_openshift_versions(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    json: bool,
+    platform: str,
+    site: Optional[str],
+):
     """Get available OpenShift Container Platform versions"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_openshift_versions(
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_openshift_versions(
         platform, site
     ).format_openshift_versions(json)

--- a/cpo/commands/fyre/info/get_openshift_versions_all_platforms.py
+++ b/cpo/commands/fyre/info/get_openshift_versions_all_platforms.py
@@ -32,9 +32,13 @@ from cpo.utils.logging import loglevel_command
 )
 @fyre_command_options
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def get_openshift_versions_all_platforms(fyre_api_user_name: str, fyre_api_key: str, site: Optional[str]):
+def get_openshift_versions_all_platforms(
+    fyre_api_user_name: str, fyre_api_key: str, disable_strict_response_schema_check: bool, site: Optional[str]
+):
     """Get available OpenShift Container Platform versions for all
     platforms"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_openshift_versions_all_platforms(site).format()
+    OCPPlusAPIManager(
+        fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check
+    ).get_openshift_versions_all_platforms(site).format()

--- a/cpo/commands/fyre/info/get_quick_burn_max_hours.py
+++ b/cpo/commands/fyre/info/get_quick_burn_max_hours.py
@@ -33,8 +33,16 @@ from cpo.utils.logging import loglevel_command
 @fyre_command_options
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def get_quick_burn_max_hours(fyre_api_user_name: str, fyre_api_key: str, json: bool, site: Optional[str]):
+def get_quick_burn_max_hours(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    json: bool,
+    site: Optional[str],
+):
     """Get the maxmimum hours for a quick burn deployment"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_quickburn_max_hours(site).format(json)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_quickburn_max_hours(
+        site
+    ).format(json)

--- a/cpo/commands/fyre/info/get_quick_burn_sizes.py
+++ b/cpo/commands/fyre/info/get_quick_burn_sizes.py
@@ -33,8 +33,16 @@ from cpo.utils.logging import loglevel_command
 @fyre_command_options
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def get_quick_burn_sizes(fyre_api_user_name: str, fyre_api_key: str, json: bool, site: Optional[str]):
+def get_quick_burn_sizes(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    json: bool,
+    site: Optional[str],
+):
     """Get available sizes for a quick burn deployment"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_quickburn_sizes(site).format(json)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_quickburn_sizes(
+        site
+    ).format(json)

--- a/cpo/commands/fyre/info/get_quota.py
+++ b/cpo/commands/fyre/info/get_quota.py
@@ -33,8 +33,16 @@ from cpo.utils.logging import loglevel_command
 @fyre_command_options
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
-def get_quota(fyre_api_user_name: str, fyre_api_key: str, json: bool, site: Optional[str]):
+def get_quota(
+    fyre_api_user_name: str,
+    fyre_api_key: str,
+    disable_strict_response_schema_check: bool,
+    json: bool,
+    site: Optional[str],
+):
     """Get quotas for product groups the given FYRE user is part of"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_quota(site).format(json)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_quota(site).format(
+        json
+    )

--- a/cpo/commands/fyre/info/get_request_status.py
+++ b/cpo/commands/fyre/info/get_request_status.py
@@ -31,8 +31,12 @@ from cpo.utils.logging import loglevel_command
 @fyre_command_options
 @click.option("--json", help="Prints the command output in JSON format", is_flag=True)
 @click.option("--request-id", help="Request ID", required=True)
-def get_request_status(fyre_api_user_name: str, fyre_api_key: str, json: bool, request_id: str):
+def get_request_status(
+    fyre_api_user_name: str, fyre_api_key: str, disable_strict_response_schema_check: bool, json: bool, request_id: str
+):
     """Get the status of a request"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_request_status(request_id).format(json)
+    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_request_status(
+        request_id
+    ).format(json)

--- a/cpo/commands/fyre/info/wait_for_request.py
+++ b/cpo/commands/fyre/info/wait_for_request.py
@@ -30,8 +30,12 @@ from cpo.utils.logging import loglevel_command
 )
 @fyre_command_options
 @click.option("--request-id", help="Request ID", required=True)
-def wait_for_request(fyre_api_user_name: str, fyre_api_key: str, request_id: str):
+def wait_for_request(
+    fyre_api_user_name: str, fyre_api_key: str, disable_strict_response_schema_check: bool, request_id: str
+):
     """Wait for request to complete"""
 
     cpo.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).wait_for_request_completion(request_id)
+    OCPPlusAPIManager(
+        fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check
+    ).wait_for_request_completion(request_id)

--- a/cpo/commands/fyre/login.py
+++ b/cpo/commands/fyre/login.py
@@ -23,7 +23,7 @@ from cpo.utils.logging import loglevel_command
 
 @loglevel_command()
 @fyre_command_options
-def login(fyre_api_user_name: str, fyre_api_key: str):
+def login(fyre_api_user_name: str, fyre_api_key: str, disable_strict_response_schema_check: bool):
     """Log in to FYRE"""
 
     credentials_to_be_stored = locals().copy()
@@ -31,7 +31,7 @@ def login(fyre_api_user_name: str, fyre_api_key: str):
     cpo.utils.network.disable_insecure_request_warning()
 
     try:
-        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key).get_quota(None)
+        OCPPlusAPIManager(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check).get_quota(None)
     except DataGateCLIException as exception:
         if "failed authentication" in exception._error_message:
             raise DataGateCLIException("Failed to log in to FYRE due to invalid credentials")

--- a/cpo/lib/fyre/ocp_plus_api_manager.py
+++ b/cpo/lib/fyre/ocp_plus_api_manager.py
@@ -104,7 +104,8 @@ class OCPPlusAPIManager:
             cluster_data,
         )
 
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str):
+    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, disable_strict_response_schema_check: bool):
+        self._disable_strict_response_schema_check = disable_strict_response_schema_check
         self._fyre_api_key = fyre_api_key
         self._fyre_api_user_name = fyre_api_user_name
 
@@ -120,7 +121,7 @@ class OCPPlusAPIManager:
         """
 
         OCPAcceptTransferPutManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, cluster_name
         ).execute_put_request()
 
     def add_node(
@@ -174,7 +175,7 @@ class OCPPlusAPIManager:
             ocp_add_additional_nodes_put_request["vm_count"] = str(worker_node_count)
 
         OCPAddAdditionalNodesPutManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, cluster_name
         ).execute_request_put_request(ocp_add_additional_nodes_put_request)
 
     def boot(self, cluster_name: str, site: Optional[str]):
@@ -189,7 +190,12 @@ class OCPPlusAPIManager:
         """
 
         OCPClusterActionManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name, "boot"
+            self._fyre_api_user_name,
+            self._fyre_api_key,
+            self._disable_strict_response_schema_check,
+            site,
+            cluster_name,
+            "boot",
         ).execute_request_put_request()
 
     def boot_node(self, cluster_name: str, node_name: str, site: Optional[str]):
@@ -206,7 +212,13 @@ class OCPPlusAPIManager:
         """
 
         OCPNodeActionManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name, node_name, "boot"
+            self._fyre_api_user_name,
+            self._fyre_api_key,
+            self._disable_strict_response_schema_check,
+            site,
+            cluster_name,
+            node_name,
+            "boot",
         ).execute_request_put_request()
 
     def check_cluster_name(self, cluster_name: str, site: Optional[str]) -> CheckHostNameData:
@@ -221,7 +233,7 @@ class OCPPlusAPIManager:
         """
 
         return CheckHostnameManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, cluster_name
         ).execute_get_request()
 
     def create_cluster(self, ocp_plus_cluster_settings: OCPPlusClusterSpecification, site: Optional[str]) -> str:
@@ -301,9 +313,9 @@ class OCPPlusAPIManager:
 
             ocp_post_request["worker"] = [worker]
 
-        ocp_post_response = OCPPostManager(self._fyre_api_user_name, self._fyre_api_key, site).execute_post_request(
-            ocp_post_request
-        )
+        ocp_post_response = OCPPostManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site
+        ).execute_post_request(ocp_post_request)
 
         self._add_cluster(ocp_plus_cluster_settings.alias, site, ocp_post_response)
 
@@ -331,7 +343,7 @@ class OCPPlusAPIManager:
             cpo.config.cluster_credentials_manager.cluster_credentials_manager.raise_if_alias_exists(alias)
 
         ocp_post_response = OCPDefaultPostManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, platform
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, platform
         ).execute_post_request()
 
         self._add_cluster(alias, site, ocp_post_response)
@@ -349,7 +361,9 @@ class OCPPlusAPIManager:
             OCP+ site
         """
 
-        OCPDisableDeleteManager(self._fyre_api_user_name, self._fyre_api_key, site, cluster_name).execute_put_request()
+        OCPDisableDeleteManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, cluster_name
+        ).execute_put_request()
 
     def edit_inf_node(self, cluster_name: str, additional_disk_sizes: List[int], site: Optional[str]):
         """Edits the infrastructure node of an OCP+ cluster
@@ -430,7 +444,9 @@ class OCPPlusAPIManager:
             OCP+ site
         """
 
-        OCPEnableDeleteManager(self._fyre_api_user_name, self._fyre_api_key, site, cluster_name).execute_put_request()
+        OCPEnableDeleteManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, cluster_name
+        ).execute_put_request()
 
     def get_cluster_details(self, cluster_name: str, site: Optional[str]) -> OCPPlusCluster:
         """Returns details of an OCP+ cluster
@@ -449,7 +465,7 @@ class OCPPlusAPIManager:
         """
 
         return OCPGetManagerForSingleCluster(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, cluster_name
         ).execute_get_request()
 
     def get_cluster_status(self, cluster_name: str, site: Optional[str]) -> OCPPlusClusterStatus:
@@ -468,7 +484,9 @@ class OCPPlusAPIManager:
             object containing the status of an OCP+ cluster
         """
 
-        return OCPStatusManager(self._fyre_api_user_name, self._fyre_api_key, site, cluster_name).execute_get_request()
+        return OCPStatusManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, cluster_name
+        ).execute_get_request()
 
     def get_clusters(self, site: Optional[str]) -> OCPPlusClusterData:
         """Returns OCP+ clusters
@@ -484,7 +502,9 @@ class OCPPlusAPIManager:
             object containing OCP+ clusters
         """
 
-        return OCPGetManager(self._fyre_api_user_name, self._fyre_api_key, site).execute_get_request()
+        return OCPGetManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site
+        ).execute_get_request()
 
     def get_default_sizes(self, platform: str, site: Optional[str]) -> OCPAvailableData:
         """Returns default node sizes
@@ -502,7 +522,9 @@ class OCPPlusAPIManager:
             object containing available OpenShift versions/default node sizes
         """
 
-        return OCPAvailableManager(self._fyre_api_user_name, self._fyre_api_key, site, platform).execute_get_request()
+        return OCPAvailableManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, platform
+        ).execute_get_request()
 
     def get_openshift_versions(self, platform: str, site: Optional[str]) -> OCPAvailableData:
         """Returns available OpenShift Container Platform versions
@@ -520,7 +542,9 @@ class OCPPlusAPIManager:
             object containing available OpenShift versions/default node sizes
         """
 
-        return OCPAvailableManager(self._fyre_api_user_name, self._fyre_api_key, site, platform).execute_get_request()
+        return OCPAvailableManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, platform
+        ).execute_get_request()
 
     def get_openshift_versions_all_platforms(self, site: Optional[str]) -> OpenShiftVersionData:
         """Returns available OpenShift Container Platform versions for all
@@ -538,19 +562,25 @@ class OCPPlusAPIManager:
         """
 
         openshift_versions_p = (
-            OCPAvailableManager(self._fyre_api_user_name, self._fyre_api_key, site, "p")
+            OCPAvailableManager(
+                self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, "p"
+            )
             .execute_get_request()
             .get_openshift_versions()
         )
 
         openshift_versions_x = (
-            OCPAvailableManager(self._fyre_api_user_name, self._fyre_api_key, site, "x")
+            OCPAvailableManager(
+                self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, "x"
+            )
             .execute_get_request()
             .get_openshift_versions()
         )
 
         openshift_versions_z = (
-            OCPAvailableManager(self._fyre_api_user_name, self._fyre_api_key, site, "z")
+            OCPAvailableManager(
+                self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, "z"
+            )
             .execute_get_request()
             .get_openshift_versions()
         )
@@ -571,7 +601,9 @@ class OCPPlusAPIManager:
             object containing maxmimum hours for a quick burn deployment
         """
 
-        return OCPQuickBurnMaxHoursManager(self._fyre_api_user_name, self._fyre_api_key, site).execute_get_request()
+        return OCPQuickBurnMaxHoursManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site
+        ).execute_get_request()
 
     def get_quickburn_sizes(self, site: Optional[str]) -> QuickBurnSizeData:
         """Returns available sizes for a quick burn deployment
@@ -587,7 +619,9 @@ class OCPPlusAPIManager:
             object containing available sizes for a quick burn deployment
         """
 
-        return OCPQuickBurnSizesManager(self._fyre_api_user_name, self._fyre_api_key, site).execute_get_request()
+        return OCPQuickBurnSizesManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site
+        ).execute_get_request()
 
     def get_quota(self, site: Optional[str]) -> ProductGroupQuotaData:
         """Returns quotas for product groups the given FYRE user is part of
@@ -604,7 +638,9 @@ class OCPPlusAPIManager:
             of
         """
 
-        return QuotaRequestManager(self._fyre_api_user_name, self._fyre_api_key, site).execute_get_request()
+        return QuotaRequestManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site
+        ).execute_get_request()
 
     def get_request_status(self, request_id: str) -> RequestStatusData:
         """Get the status of a request
@@ -620,7 +656,9 @@ class OCPPlusAPIManager:
             object containing the status of a request
         """
 
-        return OCPRequestManager(self._fyre_api_user_name, self._fyre_api_key, request_id).execute_get_request()
+        return OCPRequestManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, request_id
+        ).execute_get_request()
 
     def reboot(self, cluster_name: str, site: Optional[str]):
         """Reboots an OCP+ cluster
@@ -634,7 +672,12 @@ class OCPPlusAPIManager:
         """
 
         OCPClusterActionManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name, "reboot"
+            self._fyre_api_user_name,
+            self._fyre_api_key,
+            self._disable_strict_response_schema_check,
+            site,
+            cluster_name,
+            "reboot",
         ).execute_request_put_request()
 
     def reboot_node(self, cluster_name: str, node_name: str, site: Optional[str]):
@@ -651,7 +694,13 @@ class OCPPlusAPIManager:
         """
 
         OCPNodeActionManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name, node_name, "reboot"
+            self._fyre_api_user_name,
+            self._fyre_api_key,
+            self._disable_strict_response_schema_check,
+            site,
+            cluster_name,
+            node_name,
+            "reboot",
         ).execute_request_put_request()
 
     def redeploy_node(self, cluster_name: str, node_name: str, site: Optional[str]):
@@ -668,7 +717,13 @@ class OCPPlusAPIManager:
         """
 
         OCPNodeActionManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name, node_name, "redeploy"
+            self._fyre_api_user_name,
+            self._fyre_api_key,
+            self._disable_strict_response_schema_check,
+            site,
+            cluster_name,
+            node_name,
+            "redeploy",
         ).execute_request_put_request()
 
     def rm(self, cluster_name, site: Optional[str]):
@@ -682,7 +737,9 @@ class OCPPlusAPIManager:
             OCP+ site
         """
 
-        OCPDeleteManager(self._fyre_api_user_name, self._fyre_api_key, site, cluster_name).execute_delete_request()
+        OCPDeleteManager(
+            self._fyre_api_user_name, self._fyre_api_key, self._disable_strict_response_schema_check, site, cluster_name
+        ).execute_delete_request()
 
     def shutdown(self, cluster_name: str, site: Optional[str]):
         """Shuts down an OCP+ cluster
@@ -696,7 +753,12 @@ class OCPPlusAPIManager:
         """
 
         OCPClusterActionManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name, "shutdown"
+            self._fyre_api_user_name,
+            self._fyre_api_key,
+            self._disable_strict_response_schema_check,
+            site,
+            cluster_name,
+            "shutdown",
         ).execute_request_put_request()
 
     def shutdown_node(self, cluster_name: str, node_name: str, site: Optional[str]):
@@ -713,7 +775,13 @@ class OCPPlusAPIManager:
         """
 
         OCPNodeActionManager(
-            self._fyre_api_user_name, self._fyre_api_key, site, cluster_name, node_name, "shutdown"
+            self._fyre_api_user_name,
+            self._fyre_api_key,
+            self._disable_strict_response_schema_check,
+            site,
+            cluster_name,
+            node_name,
+            "shutdown",
         ).execute_request_put_request()
 
     def transfer(
@@ -754,6 +822,7 @@ class OCPPlusAPIManager:
         OCPTransferPutManager(
             self._fyre_api_user_name,
             self._fyre_api_key,
+            self._disable_strict_response_schema_check,
             site,
             cluster_name,
         ).execute_put_request(ocp_transfer_put_request)
@@ -785,7 +854,12 @@ class OCPPlusAPIManager:
             }
 
             OCPDiskPutManager(
-                self._fyre_api_user_name, self._fyre_api_key, site, cluster_name, node_name
+                self._fyre_api_user_name,
+                self._fyre_api_key,
+                self._disable_strict_response_schema_check,
+                site,
+                cluster_name,
+                node_name,
             ).execute_request_put_request(ocp_disk_put_request)
 
     def _add_cluster(self, alias: Optional[str], site: Optional[str], ocp_post_response: OCPPostResponse):
@@ -851,5 +925,10 @@ class OCPPlusAPIManager:
             logger.info("Changing node resources")
 
             OCPResourcePutManager(
-                self._fyre_api_user_name, self._fyre_api_key, site, cluster_name, node_name
+                self._fyre_api_user_name,
+                self._fyre_api_key,
+                self._disable_strict_response_schema_check,
+                site,
+                cluster_name,
+                node_name,
             ).execute_request_put_request(ocp_resource_put_request)

--- a/cpo/lib/fyre/request_managers/check_hostname_manager.py
+++ b/cpo/lib/fyre/request_managers/check_hostname_manager.py
@@ -22,8 +22,15 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class CheckHostnameManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], cluster_name: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        cluster_name: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
 
@@ -38,7 +45,7 @@ class CheckHostnameManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return CheckHostnameGetResponseManager()
+        return CheckHostnameGetResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_accept_transfer_put_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_accept_transfer_put_manager.py
@@ -22,10 +22,18 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPAcceptTransferPutManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], cluster_name: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        cluster_name: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
+        self._disable_strict_response_schema_check = disable_strict_response_schema_check
 
     def execute_put_request(self) -> DefaultSuccessResponse:
         return self._execute_request(HTTPMethod.PUT)
@@ -36,7 +44,7 @@ class OCPAcceptTransferPutManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_add_additional_nodes_put_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_add_additional_nodes_put_manager.py
@@ -21,10 +21,18 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPAddAdditionalNodesPutManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], cluster_name: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        cluster_name: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
+        self._disable_strict_response_schema_check = disable_strict_response_schema_check
 
     def execute_request_put_request(self, ocp_resource_put_request: Any):
         self._execute_request(HTTPMethod.PUT, ocp_resource_put_request)
@@ -35,7 +43,7 @@ class OCPAddAdditionalNodesPutManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_available_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_available_manager.py
@@ -22,8 +22,15 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPAvailableManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], platform: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        platform: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._platform = platform
 
@@ -38,7 +45,7 @@ class OCPAvailableManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return OCPAvailableGetResponseManager()
+        return OCPAvailableGetResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_cluster_action_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_cluster_action_manager.py
@@ -25,11 +25,12 @@ class OCPClusterActionManager(AbstractJSONRequestManager):
         self,
         fyre_api_user_name: str,
         fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
         site: Optional[str],
         cluster_name: str,
         action: str,
     ):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._action = action
         self._cluster_name = cluster_name
@@ -45,7 +46,7 @@ class OCPClusterActionManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_default_post_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_default_post_manager.py
@@ -22,8 +22,15 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPDefaultPostManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], platform: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        platform: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._platform = platform
 
@@ -36,7 +43,7 @@ class OCPDefaultPostManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return OCPPostResponseManager()
+        return OCPPostResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_delete_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_delete_manager.py
@@ -22,8 +22,15 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPDeleteManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], cluster_name: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        cluster_name: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
 
@@ -36,7 +43,7 @@ class OCPDeleteManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_disable_delete_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_disable_delete_manager.py
@@ -22,8 +22,15 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPDisableDeleteManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], cluster_name: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        cluster_name: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
 
@@ -36,7 +43,7 @@ class OCPDisableDeleteManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_disk_put_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_disk_put_manager.py
@@ -25,11 +25,12 @@ class OCPDiskPutManager(AbstractJSONRequestManager):
         self,
         fyre_api_user_name: str,
         fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
         site: Optional[str],
         cluster_name: str,
         node_name: str,
     ):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
         self._node_name = node_name
@@ -43,7 +44,7 @@ class OCPDiskPutManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_enable_delete_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_enable_delete_manager.py
@@ -22,8 +22,15 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPEnableDeleteManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], cluster_name: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        cluster_name: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check)
 
         self._cluster_name = cluster_name
 
@@ -36,7 +43,7 @@ class OCPEnableDeleteManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_get_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_get_manager.py
@@ -22,8 +22,14 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPGetManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str]):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
     def execute_get_request(
         self,
@@ -36,7 +42,7 @@ class OCPGetManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return OCPGetResponseManager()
+        return OCPGetResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_get_manager_for_single_cluster.py
+++ b/cpo/lib/fyre/request_managers/ocp_get_manager_for_single_cluster.py
@@ -24,8 +24,15 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPGetManagerForSingleCluster(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], cluster_name: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        cluster_name: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
 
@@ -40,7 +47,7 @@ class OCPGetManagerForSingleCluster(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return OCPGetResponseManagerForSingleCluster()
+        return OCPGetResponseManagerForSingleCluster(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_node_action_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_node_action_manager.py
@@ -25,12 +25,13 @@ class OCPNodeActionManager(AbstractJSONRequestManager):
         self,
         fyre_api_user_name: str,
         fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
         site: Optional[str],
         cluster_name: str,
         node_name: str,
         action: str,
     ):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._action = action
         self._cluster_name = cluster_name
@@ -47,7 +48,7 @@ class OCPNodeActionManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_post_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_post_manager.py
@@ -22,8 +22,14 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPPostManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str]):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
     def execute_post_request(self, ocp_post_request: Any) -> OCPPostResponse:
         return self._execute_request(HTTPMethod.POST, ocp_post_request)
@@ -34,7 +40,7 @@ class OCPPostManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return OCPPostResponseManager()
+        return OCPPostResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_quick_burn_max_hours_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_quick_burn_max_hours_manager.py
@@ -22,8 +22,14 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPQuickBurnMaxHoursManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str]):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
     def execute_get_request(
         self,
@@ -36,7 +42,7 @@ class OCPQuickBurnMaxHoursManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return OCPQuickBurnMaxHoursResponseManager()
+        return OCPQuickBurnMaxHoursResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_quick_burn_sizes_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_quick_burn_sizes_manager.py
@@ -22,8 +22,14 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPQuickBurnSizesManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str]):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
     def execute_get_request(
         self,
@@ -36,7 +42,7 @@ class OCPQuickBurnSizesManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return OCPQuickBurnSizesResponseManager()
+        return OCPQuickBurnSizesResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_resource_put_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_resource_put_manager.py
@@ -25,11 +25,12 @@ class OCPResourcePutManager(AbstractJSONRequestManager):
         self,
         fyre_api_user_name: str,
         fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
         site: Optional[str],
         cluster_name: str,
         node_name: str,
     ):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
         self._node_name = node_name
@@ -43,7 +44,7 @@ class OCPResourcePutManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_status_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_status_manager.py
@@ -22,8 +22,15 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPStatusManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], cluster_name: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        cluster_name: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
 
@@ -38,7 +45,7 @@ class OCPStatusManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return OCPStatusGetResponseManager()
+        return OCPStatusGetResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/ocp_transfer_put_manager.py
+++ b/cpo/lib/fyre/request_managers/ocp_transfer_put_manager.py
@@ -22,8 +22,15 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class OCPTransferPutManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str], cluster_name: str):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str],
+        cluster_name: str,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, self._disable_strict_response_schema_check, site)
 
         self._cluster_name = cluster_name
 
@@ -36,7 +43,7 @@ class OCPTransferPutManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return DefaultResponseManager()
+        return DefaultResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/request_managers/quota_request_manager.py
+++ b/cpo/lib/fyre/request_managers/quota_request_manager.py
@@ -22,8 +22,14 @@ from cpo.utils.http_method import HTTPMethod
 
 
 class QuotaRequestManager(AbstractJSONRequestManager):
-    def __init__(self, fyre_api_user_name: str, fyre_api_key: str, site: Optional[str] = None):
-        super().__init__(fyre_api_user_name, fyre_api_key, site)
+    def __init__(
+        self,
+        fyre_api_user_name: str,
+        fyre_api_key: str,
+        disable_strict_response_schema_check: bool,
+        site: Optional[str] = None,
+    ):
+        super().__init__(fyre_api_user_name, fyre_api_key, disable_strict_response_schema_check, site)
 
     def execute_get_request(
         self,
@@ -36,7 +42,7 @@ class QuotaRequestManager(AbstractJSONRequestManager):
 
     # override
     def get_json_response_manager(self) -> AbstractJSONResponseManager:
-        return QuotaGetResponseManager()
+        return QuotaGetResponseManager(self._disable_strict_response_schema_check)
 
     # override
     def get_request_schema(self) -> Any:

--- a/cpo/lib/fyre/response_managers/check_hostname_get_response_manager.py
+++ b/cpo/lib/fyre/response_managers/check_hostname_get_response_manager.py
@@ -21,6 +21,9 @@ from cpo.lib.fyre.types.check_hostname_get_response import CheckHostnameGetRespo
 class CheckHostnameGetResponseManager(AbstractJSONResponseManager):
     """JSON response manager for check_hostname/{name} REST endpoint (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         return None
@@ -32,7 +35,7 @@ class CheckHostnameGetResponseManager(AbstractJSONResponseManager):
     # override
     def get_response_schema(self) -> Any:
         return {
-            "additionalProperties": False,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "details": {
                     "type": "string",

--- a/cpo/lib/fyre/response_managers/default_response_manager.py
+++ b/cpo/lib/fyre/response_managers/default_response_manager.py
@@ -22,6 +22,9 @@ class DefaultResponseManager(AbstractJSONResponseManager):
     """JSON response manager for REST endpoints (PUT) returning a generic
     success response"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         return self.get_default_error_message(json_error_response)

--- a/cpo/lib/fyre/response_managers/json_response_manager.py
+++ b/cpo/lib/fyre/response_managers/json_response_manager.py
@@ -26,6 +26,9 @@ from cpo.lib.fyre.types.default_error_response import DefaulErrorResponse
 class AbstractJSONResponseManager(ABC):
     """Base class of all JSON response manager classes"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        self._disable_strict_response_schema_check = disable_strict_response_schema_check
+
     def check_response(self, json_response: Any, error_message: str):
         """Checks the given JSON response
 
@@ -85,12 +88,12 @@ class AbstractJSONResponseManager(ABC):
         """
 
         return {
-            "additionalProperties": False,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "details": {
                     "anyOf": [
                         {
-                            "additionalProperties": False,
+                            "additionalProperties": self._disable_strict_response_schema_check,
                             "properties": {
                                 "errors": {
                                     "items": {

--- a/cpo/lib/fyre/response_managers/ocp_available_get_response_manager.py
+++ b/cpo/lib/fyre/response_managers/ocp_available_get_response_manager.py
@@ -22,6 +22,9 @@ class OCPAvailableGetResponseManager(AbstractJSONResponseManager):
     """JSON response manager for ocp_available/{platform} REST endpoint
     (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         return self.get_default_error_message(json_error_response)
@@ -37,7 +40,7 @@ class OCPAvailableGetResponseManager(AbstractJSONResponseManager):
         return {
             "$defs": {
                 "defaultClusterSizeData": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "inf": {"$ref": node_size_ref},
                         "master": {"$ref": node_size_ref},
@@ -51,7 +54,7 @@ class OCPAvailableGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
                 "nodeSize": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "additional_disk_size": {"type": "string"},
                         "additional_disk": {"type": "string"},
@@ -72,7 +75,7 @@ class OCPAvailableGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
             },
-            "additionalProperties": False,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "default_size": {
                     "$ref": "#/$defs/defaultClusterSizeData",

--- a/cpo/lib/fyre/response_managers/ocp_get_response_manager.py
+++ b/cpo/lib/fyre/response_managers/ocp_get_response_manager.py
@@ -21,6 +21,9 @@ from cpo.lib.fyre.types.ocp_get_response import OCPGetResponse
 class OCPGetResponseManager(AbstractJSONResponseManager):
     """JSON response manager for ocp REST endpoint (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> str:
         return self.get_default_error_message(json_error_response)
@@ -34,7 +37,7 @@ class OCPGetResponseManager(AbstractJSONResponseManager):
         return {
             "$defs": {
                 "cluster": {
-                    "additionalProperties": True,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "access_url": {"type": "string"},
                         "auto_patch": {"type": "string"},
@@ -90,7 +93,7 @@ class OCPGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
                 "ip": {
-                    "additionalProperties": True,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "address": {"type": "string"},
                         "ip_scope": {"type": "string"},
@@ -104,7 +107,7 @@ class OCPGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
                 "vm": {
-                    "additionalProperties": True,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "additional_disk": {
                             "items": {"type": "string"},
@@ -139,7 +142,7 @@ class OCPGetResponseManager(AbstractJSONResponseManager):
             },
             "anyOf": [
                 {
-                    "additionalProperties": True,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "cluster_count": {"type": "integer"},
                         "clusters": {
@@ -154,7 +157,7 @@ class OCPGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
                 {
-                    "additionalProperties": True,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "details": {"type": "string"},
                         "status": {"const": "info"},

--- a/cpo/lib/fyre/response_managers/ocp_get_response_manager_for_single_cluster.py
+++ b/cpo/lib/fyre/response_managers/ocp_get_response_manager_for_single_cluster.py
@@ -21,6 +21,9 @@ from cpo.lib.fyre.types.ocp_get_response_for_single_cluster import OCPGetRespons
 class OCPGetResponseManagerForSingleCluster(AbstractJSONResponseManager):
     """JSON response manager for ocp/{cluster name} REST endpoint (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         return self.get_default_error_message(json_error_response)
@@ -34,7 +37,7 @@ class OCPGetResponseManagerForSingleCluster(AbstractJSONResponseManager):
         return {
             "$defs": {
                 "cluster": {
-                    "additionalProperties": True,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "access_url": {"type": "string"},
                         "auto_patch": {"type": "string"},
@@ -86,7 +89,7 @@ class OCPGetResponseManagerForSingleCluster(AbstractJSONResponseManager):
                     "type": "object",
                 },
                 "ip": {
-                    "additionalProperties": True,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "address": {"type": "string"},
                         "ip_scope": {"type": "string"},
@@ -100,7 +103,7 @@ class OCPGetResponseManagerForSingleCluster(AbstractJSONResponseManager):
                     "type": "object",
                 },
                 "vm": {
-                    "additionalProperties": True,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "additional_disk": {
                             "items": {"type": "string"},
@@ -137,7 +140,7 @@ class OCPGetResponseManagerForSingleCluster(AbstractJSONResponseManager):
                     "type": "object",
                 },
             },
-            "additionalProperties": True,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "cluster_count": {"type": "integer"},
                 "clusters": {

--- a/cpo/lib/fyre/response_managers/ocp_post_response_manager.py
+++ b/cpo/lib/fyre/response_managers/ocp_post_response_manager.py
@@ -23,6 +23,9 @@ from cpo.lib.fyre.types.ocp_post_response import OCPPostErrorResponse, OCPPostRe
 class OCPPostResponseManager(AbstractJSONResponseManager):
     """JSON response manager for ocp REST endpoint (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         validate(json_error_response, self.get_error_response_schema())
@@ -52,7 +55,7 @@ class OCPPostResponseManager(AbstractJSONResponseManager):
     # override
     def get_error_response_schema(self) -> Optional[Any]:
         return {
-            "additionalProperties": False,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "build_errors": {
                     "items": {

--- a/cpo/lib/fyre/response_managers/ocp_quick_burn_max_hours_response_manager.py
+++ b/cpo/lib/fyre/response_managers/ocp_quick_burn_max_hours_response_manager.py
@@ -22,6 +22,9 @@ class OCPQuickBurnMaxHoursResponseManager(AbstractJSONResponseManager):
     """JSON response manager for ocp/quick_burn_max_hours REST endpoint
     (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         return None
@@ -33,7 +36,7 @@ class OCPQuickBurnMaxHoursResponseManager(AbstractJSONResponseManager):
     # override
     def get_response_schema(self) -> Any:
         return {
-            "additionalProperties": False,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "quick_burn_max_hours": {"type": "string"},
             },

--- a/cpo/lib/fyre/response_managers/ocp_quick_burn_sizes_response_manager.py
+++ b/cpo/lib/fyre/response_managers/ocp_quick_burn_sizes_response_manager.py
@@ -21,6 +21,9 @@ from cpo.lib.fyre.types.ocp_quick_burn_sizes_response import OCPQuickBurnSizesRe
 class OCPQuickBurnSizesResponseManager(AbstractJSONResponseManager):
     """JSON response manager for ocp/quick_burn_sizes REST endpoint (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         return None
@@ -36,7 +39,7 @@ class OCPQuickBurnSizesResponseManager(AbstractJSONResponseManager):
         return {
             "$defs": {
                 "nodeSizeSpecification": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "additional_disk": {
                             "type": "string",
@@ -66,7 +69,7 @@ class OCPQuickBurnSizesResponseManager(AbstractJSONResponseManager):
                     ],
                 },
                 "nodeSizeSpecificationData": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "inf": {
                             "$ref": node_size_specification_ref,
@@ -85,7 +88,7 @@ class OCPQuickBurnSizesResponseManager(AbstractJSONResponseManager):
                     ],
                 },
                 "platformQuickBurnSizeSpecificationData": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "large": {
                             "$ref": "#/$defs/nodeSizeSpecificationData",
@@ -100,7 +103,7 @@ class OCPQuickBurnSizesResponseManager(AbstractJSONResponseManager):
                     ],
                 },
             },
-            "additionalProperties": False,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "p": {
                     "$ref": "#/$defs/platformQuickBurnSizeSpecificationData",

--- a/cpo/lib/fyre/response_managers/ocp_request_get_response_manager.py
+++ b/cpo/lib/fyre/response_managers/ocp_request_get_response_manager.py
@@ -21,6 +21,9 @@ from cpo.lib.fyre.types.ocp_request_get_response import OCPRequestGetResponse
 class OCPRequestGetResponseManager(AbstractJSONResponseManager):
     """JSON response manager for ocp/request/{request_id} REST endpoint (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         return self.get_default_error_message(json_error_response)
@@ -34,7 +37,7 @@ class OCPRequestGetResponseManager(AbstractJSONResponseManager):
         return {
             "$defs": {
                 "request": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "complete": {"type": "string"},
                         "completion_percent": {"type": "integer"},
@@ -45,7 +48,7 @@ class OCPRequestGetResponseManager(AbstractJSONResponseManager):
                         "last_status": {
                             "anyOf": [
                                 {
-                                    "additionalProperties": False,
+                                    "additionalProperties": self._disable_strict_response_schema_check,
                                     "properties": {
                                         "cluster_id": {"type": "string"},
                                         "status": {"type": "string"},
@@ -78,7 +81,7 @@ class OCPRequestGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
             },
-            "additionalProperties": False,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "request": {"$ref": "#/$defs/request"},
                 "status": {"type": "string"},

--- a/cpo/lib/fyre/response_managers/ocp_status_get_response_manager.py
+++ b/cpo/lib/fyre/response_managers/ocp_status_get_response_manager.py
@@ -22,6 +22,9 @@ class OCPStatusGetResponseManager(AbstractJSONResponseManager):
     """JSON response manager for ocp/{cluster name}/status REST endpoint
     (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         return self.get_default_error_message(json_error_response)
@@ -35,12 +38,12 @@ class OCPStatusGetResponseManager(AbstractJSONResponseManager):
         return {
             "$defs": {
                 "vm": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "job_status": {
                             "anyOf": [
                                 {
-                                    "additionalProperties": False,
+                                    "additionalProperties": self._disable_strict_response_schema_check,
                                     "properties": {
                                         "completion_percent": {"type": "integer"},
                                         "status": {"type": "string"},
@@ -78,7 +81,7 @@ class OCPStatusGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
                 "request": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "complete": {"type": "string"},
                         "completion_percent": {"type": "integer"},
@@ -102,7 +105,7 @@ class OCPStatusGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
             },
-            "additionalProperties": False,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "cluster_id": {"type": "string"},
                 "cluster_name": {"type": "string"},
@@ -114,7 +117,7 @@ class OCPStatusGetResponseManager(AbstractJSONResponseManager):
                 "status": {
                     "anyOf": [
                         {
-                            "additionalProperties": False,
+                            "additionalProperties": self._disable_strict_response_schema_check,
                             "properties": {
                                 "active_requests": {"type": "integer"},
                                 "request": {

--- a/cpo/lib/fyre/response_managers/quota_get_response_manager.py
+++ b/cpo/lib/fyre/response_managers/quota_get_response_manager.py
@@ -21,6 +21,9 @@ from cpo.lib.fyre.types.quota_get_response import QuotaGetResponse
 class QuotaGetResponseManager(AbstractJSONResponseManager):
     """JSON response manager for quota REST endpoint (GET)"""
 
+    def __init__(self, disable_strict_response_schema_check: bool):
+        super().__init__(disable_strict_response_schema_check)
+
     # override
     def get_error_message(self, json_error_response: Any) -> Optional[str]:
         return self.get_default_error_message(json_error_response)
@@ -36,7 +39,7 @@ class QuotaGetResponseManager(AbstractJSONResponseManager):
         return {
             "$defs": {
                 "platformQuota": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "cpu_percent": {"type": "integer"},
                         "cpu_used": {"type": "integer"},
@@ -56,7 +59,7 @@ class QuotaGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
                 "productGroupQuota": {
-                    "additionalProperties": False,
+                    "additionalProperties": self._disable_strict_response_schema_check,
                     "properties": {
                         "ip": {
                             "properties": {
@@ -96,7 +99,7 @@ class QuotaGetResponseManager(AbstractJSONResponseManager):
                     "type": "object",
                 },
             },
-            "additionalProperties": False,
+            "additionalProperties": self._disable_strict_response_schema_check,
             "properties": {
                 "details": {
                     "items": {"$ref": "#/$defs/productGroupQuota"},

--- a/cpo/lib/fyre/utils/click.py
+++ b/cpo/lib/fyre/utils/click.py
@@ -25,6 +25,11 @@ def fyre_command_optgroup_options(f: Callable[..., Any]) -> Callable[..., Any]:
     options = [
         optgroup.option("--fyre-api-key", help="FYRE API key (see https://fyre.svl.ibm.com/account)", required=True),
         optgroup.option("--fyre-api-user-name", help="FYRE API user name", required=True),
+        optgroup.option(
+            "--disable-strict-response-schema-check",
+            help="Disable strict schema check for OCP+ API response",
+            is_flag=True,
+        ),
     ]
 
     return functools.reduce(lambda result, option: option(result), options, f)
@@ -34,6 +39,11 @@ def fyre_command_options(f: Callable[..., Any]) -> Callable[..., Any]:
     options = [
         click.option("--fyre-api-key", help="FYRE API key (see https://fyre.svl.ibm.com/account)", required=True),
         click.option("--fyre-api-user-name", help="FYRE API user name", required=True),
+        click.option(
+            "--disable-strict-response-schema-check",
+            help="Disable strict schema check for OCP+ API response",
+            is_flag=True,
+        ),
     ]
 
     return functools.reduce(lambda result, option: option(result), options, f)


### PR DESCRIPTION
This pull request adds a `--disable-strict-response-schema-check` option to all Fyre commands. This flag may be used if a JSON response message contains one or more additional keys due to a change of the OCP+ APIs. Without this flag, the CLI would throw an error and the JSON schema would have to be updated first.