### PR TITLE
Fix Jenkins pipeline

### DIFF
--- a/cpo/lib/fyre/response_managers/ocp_get_response_manager_for_single_cluster.py
+++ b/cpo/lib/fyre/response_managers/ocp_get_response_manager_for_single_cluster.py
@@ -52,6 +52,7 @@ class OCPGetResponseManagerForSingleCluster(AbstractJSONResponseManager):
                         "expiration": {"type": "string"},
                         "fips_enabled": {"type": "string"},
                         "initial_ocp_version": {"type": "string"},
+                        "kubeadmin_password": {"type": "string"},
                         "locked_for_delete": {"type": "string"},
                         "ocp_username": {"type": "string"},
                         "ocp_version": {"type": "string"},

--- a/cpo/lib/fyre/types/ocp_get_response_for_single_cluster.py
+++ b/cpo/lib/fyre/types/ocp_get_response_for_single_cluster.py
@@ -46,6 +46,7 @@ class Cluster(TypedDict):
     description: str
     expiration: str
     fips_enabled: str
+    kubeadmin_password: Optional[str]
     locked_for_delete: str
     ocp_username: str
     ocp_version: str


### PR DESCRIPTION
This pull request contains the following changes:

- Re-add `kubeadmin_password` to OCP+ API response schema but make it optional (sometimes this key and the corresponding value are returned, sometimes not)

The Jenkins build pipeline is finally [green](https://idaa-jenkins.swg-devops.com/job/data-gate/job/data-gate-cli/job/fix_jenkins_pipeline/1/) again.