### PR TITLE
feat: Authenticate by asking for flags instead of showing a prompt

### DIFF
--- a/cpo/commands/adm/ibm_internal_plugin/install.py
+++ b/cpo/commands/adm/ibm_internal_plugin/install.py
@@ -21,7 +21,17 @@ from cpo.utils.logging import loglevel_command
 
 @loglevel_command()
 @click.argument("distribution-package-name")
-def install(distribution_package_name: str):
+@click.option(
+    "--artifactory-username",
+    help="Artifactory username. The username is usually the IBM e-mail address.",
+    required=True,
+)
+@click.option(
+    "--artifactory-password",
+    help="Artifactory password. The password is usually the API Key located in the 'Edit profile' page in Artifactory.",
+    required=True,
+)
+def install(distribution_package_name: str, artifactory_username: str, artifactory_password: str):
     """Install an IBM-internal CLI plug-in"""
 
-    cpo.lib.ibm_internal_plugin.install.install(distribution_package_name)
+    cpo.lib.ibm_internal_plugin.install.install(distribution_package_name, artifactory_username, artifactory_password)

--- a/cpo/commands/adm/ibm_internal_plugin/install.py
+++ b/cpo/commands/adm/ibm_internal_plugin/install.py
@@ -28,7 +28,7 @@ from cpo.utils.logging import loglevel_command
 )
 @click.option(
     "--artifactory-password",
-    help="Artifactory password. The password is usually the API Key located in the 'Edit profile' page in Artifactory.",
+    help="Artifactory password. The password is usually the API Key located in the 'Edit Profile' page in Artifactory.",
     required=True,
 )
 def install(distribution_package_name: str, artifactory_username: str, artifactory_password: str):

--- a/cpo/commands/adm/ibm_internal_plugin/list.py
+++ b/cpo/commands/adm/ibm_internal_plugin/list.py
@@ -27,7 +27,7 @@ from cpo.utils.logging import loglevel_command
 )
 @click.option(
     "--artifactory-password",
-    help="Artifactory password. The password is usually the API Key located in the 'Edit profile' page in Artifactory.",
+    help="Artifactory password. The password is usually the API Key located in the 'Edit Profile' page in Artifactory.",
     required=True,
 )
 def list(artifactory_username, artifactory_password):

--- a/cpo/commands/adm/ibm_internal_plugin/list.py
+++ b/cpo/commands/adm/ibm_internal_plugin/list.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import click
 
 import cpo.lib.ibm_internal_plugin.list
 
@@ -19,7 +20,17 @@ from cpo.utils.logging import loglevel_command
 
 
 @loglevel_command()
-def list():
+@click.option(
+    "--artifactory-username",
+    help="Artifactory username. The username is usually the IBM e-mail address.",
+    required=True,
+)
+@click.option(
+    "--artifactory-password",
+    help="Artifactory password. The password is usually the API Key located in the 'Edit profile' page in Artifactory.",
+    required=True,
+)
+def list(artifactory_username, artifactory_password):
     """List available IBM-internal CLI plug-ins"""
 
-    cpo.lib.ibm_internal_plugin.list.list()
+    cpo.lib.ibm_internal_plugin.list.list(artifactory_username, artifactory_password)

--- a/cpo/lib/ibm_internal_plugin/install.py
+++ b/cpo/lib/ibm_internal_plugin/install.py
@@ -15,7 +15,7 @@
 import cpo.utils.process
 
 
-def install(distribution_package_name: str):
+def install(distribution_package_name: str, artifactory_username: str, artifactory_password: str):
     """Installs the distribution package with the given name"""
 
     cpo.utils.process.execute_command(
@@ -24,6 +24,9 @@ def install(distribution_package_name: str):
             "install",
             distribution_package_name,
             "--index-url",
-            "https://na.artifactory.swg-devops.com/artifactory/api/pypi/idaa-data-gate-cli-pypi-local/simple",
+            (
+                f"https://{artifactory_username}:{artifactory_password}@"
+                "na.artifactory.swg-devops.com/artifactory/api/pypi/idaa-data-gate-cli-pypi-local/simple"
+            ),
         ],
     )

--- a/cpo/lib/ibm_internal_plugin/list.py
+++ b/cpo/lib/ibm_internal_plugin/list.py
@@ -16,7 +16,7 @@
 import cpo.utils.process
 
 
-def list():
+def list(artifactory_username: str, artifactory_password: str):
     """Lists IBM-internal CLI plug-ins"""
 
     cpo.utils.process.execute_command(
@@ -24,7 +24,10 @@ def list():
         [
             "search",
             "--index",
-            "https://na.artifactory.swg-devops.com/artifactory/api/pypi/idaa-data-gate-cli-pypi-local/simple",
-            "cloud-pak-operations-cli"
+            (
+                f"https://{artifactory_username}:{artifactory_password}@"
+                "na.artifactory.swg-devops.com/artifactory/api/pypi/idaa-data-gate-cli-pypi-local/simple"
+            ),
+            "cloud-pak-operations-cli",
         ],
     )


### PR DESCRIPTION
This PR allows to authenticate by asking for flags instead of showing a prompt. This feature is necessary to use the plugin in our teams pipeline.