### PR TITLE
Add --login option to 'cluster use' command

### DIFF
--- a/cpo/commands/cluster/use.py
+++ b/cpo/commands/cluster/use.py
@@ -21,7 +21,15 @@ from cpo.utils.logging import loglevel_command
 
 @loglevel_command()
 @click.argument("alias_or_server")
-def use(alias_or_server: str):
+@click.option(
+    "--login",
+    help="Log in to the current OpenShift cluster",
+    is_flag=True,
+)
+def use(alias_or_server: str, login: bool):
     """Set the current registered OpenShift cluster"""
 
-    cpo.config.cluster_credentials_manager.cluster_credentials_manager.set_cluster(alias_or_server)
+    current_cluster = cpo.config.cluster_credentials_manager.cluster_credentials_manager.set_cluster(alias_or_server)
+
+    if login:
+        current_cluster.login()

--- a/cpo/config/cluster_credentials_manager.py
+++ b/cpo/config/cluster_credentials_manager.py
@@ -319,7 +319,7 @@ class ClusterCredentialsManager:
 
         self._save_clusters_file()
 
-    def set_cluster(self, alias_or_server: str):
+    def set_cluster(self, alias_or_server: str) -> AbstractCluster:
         """Sets the current registered OpenShift cluster
 
         Parameters
@@ -327,6 +327,12 @@ class ClusterCredentialsManager:
         alias_or_server
             alias or server URL of the registered OpenShift cluster to be set as
             the current cluster
+
+        Returns
+        -------
+        AbstractCluster
+            metadata of the registered OpenShift cluster with the given alias or
+            server URL
         """
 
         cluster = self.get_cluster(alias_or_server)
@@ -336,6 +342,8 @@ class ClusterCredentialsManager:
 
         self._clusters_file_contents["current_cluster"] = cluster.get_server()
         self._save_clusters_file()
+
+        return cluster
 
     def _get_clusters(self) -> Dict[str, ClusterData]:
         """Returns registered OpenShift clusters


### PR DESCRIPTION
This pull request adds a `--login` option to the `cluster use` command, which allows logging in to the OpenShift cluster with the given alias or server URL.