### PR TITLE
Require cluster type when creating OpenShift cluster using OpenShiftI…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
 	"[python]": {
 		"editor.codeActionsOnSave": {
-			"source.organizeImports": true
+			"source.organizeImports": "explicit"
 		},
 		"editor.defaultFormatter": "ms-python.black-formatter"
 	},


### PR DESCRIPTION
…nstallationManager (breaking change)

Rename 'openshift_install_cluster_id' key to 'cluster_id' in ~/.cpo/clusters.json (breaking change)